### PR TITLE
Added parser options: DefaultDuration

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -60,8 +60,7 @@ func ParseString(s string, opts ...ParseOpt) (cr *CronRange, err error) {
 	var defaultDuration *time.Duration = nil
 
 	for _, opt := range opts {
-		switch opt := opt.(type) {
-		case DefaultDuration:
+		if opt, ok := opt.(DefaultDuration); ok {
 			duration := time.Duration(opt)
 			defaultDuration = &duration
 		}

--- a/serialize.go
+++ b/serialize.go
@@ -42,11 +42,29 @@ func (cr CronRange) String() string {
 	return sb.String()
 }
 
+// ParseOpt Specifies an interface for parser opts
+type ParseOpt interface{}
+
+// DefaultDuration provides a fallback duration if the cron doesn't specify one. Duration must be 1 minute or greater
+type DefaultDuration time.Duration
+
 // ParseString attempts to deserialize the given expression or return failure if any parsing errors occur.
-func ParseString(s string) (cr *CronRange, err error) {
+// ParseOpts can include: DefaultDuration(1 * time.Minute) to set a duration. Must be greater than 1 minute. Units smaller
+// than a minute are truncated. using uint64 type conversation from duration.
+func ParseString(s string, opts ...ParseOpt) (cr *CronRange, err error) {
 	if len(s) == 0 {
 		err = errEmptyExpr
 		return
+	}
+
+	var defaultDuration *time.Duration = nil
+
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case DefaultDuration:
+			duration := time.Duration(opt)
+			defaultDuration = &duration
+		}
 	}
 
 	var (
@@ -87,6 +105,8 @@ PL:
 	if err == nil {
 		if len(durStr) > 0 {
 			cr, err = New(cronExpr, timeZone, durMin)
+		} else if defaultDuration != nil {
+			cr, err = New(cronExpr, timeZone, uint64(*defaultDuration/time.Minute))
 		} else {
 			err = errMissDurationExpr
 		}


### PR DESCRIPTION
I've added a defautl duration as required for my usecase.

It changes the signature to the Parse function but by using vargs it shouldn't impact any existing usage. I have extended the test cases to match too.

A futher extension I would consider for my use-case is: DisableCustomDuration to force the default duration. (Or perhaps it would be "ForceDuration?") 

I haven't found a "great" way of doing opt args for options. This is typically how I do it. I have also seen people use it as an internal struct modifier ie:

```go
type Opts struct {
 defautlDuration *time.Duration
}

type ParserOpt interface {
  Apply(o *Opts) error
}

type DefaultDuration time.Duration

func (dd DefaultDuration) Apply(o *Opts) error {
  var t time.Duration = time.Duration(dd)
  o.defaultDuration = &t
  return nil 
}

...
for _ opt := range opts { opt.apply(&opts) }
...
```