### PR TITLE
Use time.Duration & Allow custom cron.Parser

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -57,6 +57,8 @@ var (
 	crThirdDayEachMonthHonolulu, _ = New("0 0 3 * *", timeZoneHonolulu, 1440)
 	crFirstHourFeb29, _            = New("0 0 29 2 *", "", 60)
 	crFirstHourFeb28OrSun, _       = New("0 0 28 2 0", "", 60)
+	crEvery1MinV2, _               = Create(exprEveryMin, emptyString, time.Minute*1, cronParser)
+	crEveryNewYearsDayTokyoV2, _   = Create(exprEveryNewYear, timeZoneTokyo, time.Hour*24, cronParser)
 )
 
 type tempTestWithPointer struct {

--- a/cronrange.go
+++ b/cronrange.go
@@ -62,9 +62,9 @@ func (cr *CronRange) CronExpression() string {
 	return cr.cronExpression
 }
 
-func new(cronExpr, timeZone string, duration time.Duration, cp cron.Parser) (cr *CronRange, err error) {
+func new(cronExpr, timeZone string, dur time.Duration, cp cron.Parser) (cr *CronRange, err error) {
 	// Precondition check
-	if duration <= 0 {
+	if dur <= 0 {
 		err = errZeroDuration
 		return
 	}
@@ -89,7 +89,7 @@ func new(cronExpr, timeZone string, duration time.Duration, cp cron.Parser) (cr 
 	cr = &CronRange{
 		cronExpression: cronExpr,
 		timeZone:       timeZone,
-		duration:       duration,
+		duration:       dur,
 		schedule:       schedule,
 	}
 	return

--- a/function.go
+++ b/function.go
@@ -48,7 +48,7 @@ func (cr *CronRange) IsWithin(t time.Time) (within bool) {
 	cr.checkPrecondition()
 
 	within = false
-	searchStart := t.Add(-(cr.duration + 1*time.Second))
+	searchStart := t.Add(-(cr.duration + 1*time.Second - 1*time.Nanosecond))
 	rangeStart := cr.schedule.Next(searchStart)
 	rangeEnd := rangeStart.Add(cr.duration)
 

--- a/serialize.go
+++ b/serialize.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/robfig/cron/v3"
 )
 
 var (
@@ -28,7 +30,11 @@ func (cr CronRange) String() string {
 	sb.Grow(36)
 	if cr.duration > 0 {
 		sb.WriteString(strMarkDuration)
-		sb.WriteString(strconv.FormatUint(uint64(cr.duration/time.Minute), 10))
+		if cr.version == Version2 {
+			sb.WriteString(cr.duration.String())
+		} else {
+			sb.WriteString(strconv.FormatUint(uint64(cr.duration/time.Minute), 10))
+		}
 		sb.WriteString(strSemicolon)
 		sb.WriteString(strSingleWhitespace)
 	}
@@ -44,6 +50,11 @@ func (cr CronRange) String() string {
 
 // ParseString attempts to deserialize the given expression or return failure if any parsing errors occur.
 func ParseString(s string) (cr *CronRange, err error) {
+	cr, err = parseString(s, cronParser)
+	return
+}
+
+func parseString(s string, cp cron.Parser) (cr *CronRange, err error) {
 	if s == "" {
 		err = errEmptyExpr
 		return
@@ -54,6 +65,8 @@ func ParseString(s string) (cr *CronRange, err error) {
 		durMin                     uint64
 		parts                      = strings.Split(s, strSemicolon)
 		idxExpr                    = len(parts) - 1
+		version                    int
+		duration                   time.Duration
 	)
 	if idxExpr == 0 {
 		err = errIncompleteExpr
@@ -74,8 +87,17 @@ PL:
 			cronExpr = part
 		case strings.HasPrefix(part, strMarkDuration):
 			durStr = part[len(strMarkDuration):]
+			if duration, err = time.ParseDuration(durStr); err == nil {
+				if duration > 0 {
+					version = Version2
+				}
+			}
 			if durMin, err = strconv.ParseUint(durStr, 10, 64); err != nil {
-				break PL
+				if version != Version2 {
+					break PL
+				} else {
+					err = nil
+				}
 			}
 		case strings.HasPrefix(part, strMarkTimeZone):
 			timeZone = part[len(strMarkTimeZone):]
@@ -86,11 +108,20 @@ PL:
 
 	if err == nil {
 		if len(durStr) > 0 {
-			cr, err = New(cronExpr, timeZone, durMin)
+			if version == Version2 {
+				cr, err = Create(cronExpr, timeZone, duration, cp)
+			} else {
+				cr, err = new(cronExpr, timeZone, time.Duration(durMin)*time.Minute, cp)
+			}
 		} else {
 			err = errMissDurationExpr
 		}
 	}
+	return
+}
+
+func ParseStringWithCronParser(s string, cp cron.Parser) (cr *CronRange, err error) {
+	cr, err = parseString(s, cronParser)
 	return
 }
 

--- a/serialize.go
+++ b/serialize.go
@@ -95,9 +95,8 @@ PL:
 			if durMin, err = strconv.ParseUint(durStr, 10, 64); err != nil {
 				if version != Version2 {
 					break PL
-				} else {
-					err = nil
 				}
+				err = nil
 			}
 		case strings.HasPrefix(part, strMarkTimeZone):
 			timeZone = part[len(strMarkTimeZone):]
@@ -121,7 +120,7 @@ PL:
 }
 
 func ParseStringWithCronParser(s string, cp cron.Parser) (cr *CronRange, err error) {
-	cr, err = parseString(s, cronParser)
+	cr, err = parseString(s, cp)
 	return
 }
 

--- a/serialize.go
+++ b/serialize.go
@@ -50,11 +50,11 @@ func (cr CronRange) String() string {
 
 // ParseString attempts to deserialize the given expression or return failure if any parsing errors occur.
 func ParseString(s string) (cr *CronRange, err error) {
-	cr, err = parseString(s, cronParser)
+	cr, err = internalParseString(s, cronParser)
 	return
 }
 
-func parseString(s string, cp cron.Parser) (cr *CronRange, err error) {
+func internalParseString(s string, cp cron.Parser) (cr *CronRange, err error) {
 	if s == "" {
 		err = errEmptyExpr
 		return
@@ -110,7 +110,7 @@ PL:
 			if version == Version2 {
 				cr, err = Create(cronExpr, timeZone, duration, cp)
 			} else {
-				cr, err = new(cronExpr, timeZone, time.Duration(durMin)*time.Minute, cp)
+				cr, err = internalNew(cronExpr, timeZone, time.Duration(durMin)*time.Minute, cp)
 			}
 		} else {
 			err = errMissDurationExpr
@@ -120,7 +120,7 @@ PL:
 }
 
 func ParseStringWithCronParser(s string, cp cron.Parser) (cr *CronRange, err error) {
-	cr, err = parseString(s, cp)
+	cr, err = internalParseString(s, cp)
 	return
 }
 

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/robfig/cron/v3"
 )
 
 func TestCronRange_String(t *testing.T) {
@@ -19,12 +21,14 @@ func TestCronRange_String(t *testing.T) {
 		{"Use string() instead of sprintf", crEvery1Min, "DR=1; * * * * *"},
 		{"Use instance instead of pointer", crEvery1Min, "DR=1; * * * * *"},
 		{"1min duration without time zone", crEvery1Min, "DR=1; * * * * *"},
+		{"1min duration without time zone V2", crEvery1MinV2, "DR=1m0s; * * * * *"},
 		{"5min duration without time zone", crEvery5Min, "DR=5; */5 * * * *"},
 		{"10min duration with local time zone", crEvery10MinLocal, "DR=10; */10 * * * *"},
 		{"10min duration with time zone", crEvery10MinBangkok, "DR=10; TZ=Asia/Bangkok; */10 * * * *"},
 		{"Every Xmas morning in NYC", crEveryXmasMorningNYC, "DR=240; TZ=America/New_York; 0 8 25 12 *"},
 		{"Every New Year's Day in Bangkok", crEveryNewYearsDayBangkok, "DR=1440; TZ=Asia/Bangkok; 0 0 1 1 *"},
 		{"Every New Year's Day in Tokyo", crEveryNewYearsDayTokyo, "DR=1440; TZ=Asia/Tokyo; 0 0 1 1 *"},
+		{"Every New Year's Day in Tokyo V2", crEveryNewYearsDayTokyoV2, "DR=24h0m0s; TZ=Asia/Tokyo; 0 0 1 1 *"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,6 +86,52 @@ func TestParseString(t *testing.T) {
 	for _, tt := range deserializeTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			gotCr, err := ParseString(tt.inputS)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseString() error: %v, wantErr: %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && (gotCr == nil || gotCr.schedule == nil || gotCr.duration == 0) {
+				t.Errorf("ParseString() incomplete gotCr: %v", gotCr)
+				return
+			}
+			if !tt.wantErr && gotCr.String() != tt.wantS {
+				t.Errorf("ParseString() gotCr: %s, want: %s", gotCr.String(), tt.wantS)
+			}
+		})
+	}
+}
+
+var deserializeV2TestCases = []struct {
+	name    string
+	inputS  string
+	wantS   string
+	wantErr bool
+	cp      cron.Parser
+}{
+	{"Empty string", emptyString, emptyString, true, cronParser},
+	{"Invalid expression", "hello", emptyString, true, cronParser},
+	{"Missing duration", "; * * * * *", emptyString, true, cronParser},
+	{"Invalid duration=0", "DR=0m;* * * * *", emptyString, true, cronParser},
+	{"Invalid duration=-5", "DR=-5m;* * * * *", emptyString, true, cronParser},
+	{"Invalid with Mars time zone", "DR=5m;TZ=Mars;* * * * *", emptyString, true, cronParser},
+	{"Invalid with unknown part", "DR=10m; TZ=Pacific/Honolulu; SET=1; * * * * *", emptyString, true, cronParser},
+	{"Invalid with lower case", "dr=5m;* * * * *", emptyString, true, cronParser},
+	{"Invalid with wrong order", "* * * * *; DR=5m;", emptyString, true, cronParser},
+	{"Normal without timezone", "DR=5m;* * * * *", "DR=5m0s; * * * * *", false, cronParser},
+	{"Normal with extra whitespaces", "  DR=6m ;  * * * * *  ", "DR=6m0s; * * * * *", false, cronParser},
+	{"Normal with empty parts", ";  DR=7m;;; ;; ;; ;* * * * *  ", "DR=7m0s; * * * * *", false, cronParser},
+	{"Normal with different order", "TZ=Asia/Tokyo;  DR=1440m;  0 0 1 1 *", "DR=24h0m0s; TZ=Asia/Tokyo; 0 0 1 1 *", false, cronParser},
+	{"Normal with local time zone", "DR=8m;TZ=Local;* * * * *", "DR=8m0s; * * * * *", false, cronParser},
+	{"Normal with UTC time zone", "DR=9m;TZ=Etc/UTC;* * * * *", "DR=9m0s; TZ=Etc/UTC; * * * * *", false, cronParser},
+	{"Normal with Honolulu time zone", "DR=10m;TZ=Pacific/Honolulu;* * * * *", "DR=10m0s; TZ=Pacific/Honolulu; * * * * *", false, cronParser},
+	{"Normal with Honolulu time zone in different order", "TZ=Pacific/Honolulu; DR=10m; * * * * *", "DR=10m0s; TZ=Pacific/Honolulu; * * * * *", false, cronParser},
+	{"Normal with complicated expression", "DR=5258765m;   TZ=Pacific/Honolulu;   4,8,22,27,33,38,47,50 3,11,14-16,19,21,22 */10 1,3,5,6,9-11 1-5", "DR=87646h5m0s; TZ=Pacific/Honolulu; 4,8,22,27,33,38,47,50 3,11,14-16,19,21,22 */10 1,3,5,6,9-11 1-5", false, cronParser},
+}
+
+func TestParseStringWithCronParser(t *testing.T) {
+	for _, tt := range deserializeV2TestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCr, err := ParseStringWithCronParser(tt.inputS, tt.cp)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseString() error: %v, wantErr: %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Hi,
I have made some change to support some new features. The new methods `ParseStringWithCronParser` and `Create` allow users to pass their own `cron.Parser`, which someone may need an optional "seconds" field. And `time.Duration` is used for someone need second level accuration.
The `version` is used to keep compatible, for the string representation may be different.